### PR TITLE
Improve portability by making the startup script POSIX compliant

### DIFF
--- a/helper
+++ b/helper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 IMAGE=ghcr.io/ucla-cs-35l/assign3
 


### PR DESCRIPTION
POSIX defines `sh` as the standard shell: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html

The hard-coded `#!/bin/bash` has failed on my system before, see: https://github.com/synaptics-astra/usb-tool/pull/12/files